### PR TITLE
* Get CSS::Inliner to work on subclasses of HTML::TreeBuilder too

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,8 @@ WriteMakefile(
         'HTML::Query' => 0.09,
         'LWP' => 0,
         'URI' => 0,
-        'Test::More' => 0
+        'Test::More' => 0,
+        'Scalar::Util' => 0
     },
     'test' => {
 	TESTS => join(' ', map { glob } qw( t/*.t t/*/*.t )),

--- a/lib/CSS/Inliner.pm
+++ b/lib/CSS/Inliner.pm
@@ -9,6 +9,7 @@ use Carp;
 use Encode;
 use LWP::UserAgent;
 use URI;
+use Scalar::Util 'blessed';
 
 use HTML::Query 'query';
 
@@ -91,7 +92,7 @@ sub new {
 
   # passed in html_tree argument must be of correct type
   # TODO: make sure tree has no content already
-  if (defined $$params{html_tree} && $$params{html_tree} && ref $$params{html_tree} ne 'HTML::TreeBuilder') {
+  if (defined $$params{html_tree} && blessed( $$params{html_tree} ) && !$$params{html_tree}->isa( 'HTML::TreeBuilder' ) ) {
     croak 'Incompatible argument passed to new: "html_tree"';
   }
 


### PR DESCRIPTION
CSS::Inliner is great, but in one of my applications, i had to subclass HTML::TreeBuilder. CSS::Inliner will not work on those. This PR just makes sure that either html_tree is either HTML::TreeBuilder or one of its subclasses.
