### PR TITLE
Removing certain unicode characters

### DIFF
--- a/t/html/utf8test.html
+++ b/t/html/utf8test.html
@@ -16,7 +16,7 @@
   border: 1px solid green;
 }
 
-div.☍ p#⌘ + em {
+div.ㅒ p#় + em {
   font-size: 100px;
 }
 
@@ -24,11 +24,11 @@ a::after {
     content: "泌 數 索 參";
 }
 
-p.⌧::before {
+p.ൠ::before {
   content: "➜";
 }
 
-[class$="Ø"], p#░▒▓ {
+[class$="Ø"], p#ႮႯႰ {
   color: #fcf;
 }
 
@@ -36,7 +36,7 @@ p.⌧::before {
   border: 5px solid #00ffcf;
 }
 
-div.ಠ_ಠ p#░▒▓ > span {
+div.ಠ_ಠ p#ႮႯႰ > span {
   display:block;
   padding:100px;
 }
@@ -61,8 +61,8 @@ em.ଽ {
 <body>
   <div class="ಠ_ಠ">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    <p class="⌧">Nam quis ullamcorper</p>
-    <p id="░▒▓">ิ ี ึ ื ุ ู ฺ<span>ஜ ஞ ட ண</span><span title="Ŏ">bĀgs of ৱ</p>
+    <p class="ൠ">Nam quis ullamcorper</p>
+    <p id="ႮႯႰ">ิ ี ึ ื ุ ู ฺ<span>ஜ ஞ ட ண</span><span title="Ŏ">bĀgs of ৱ</p>
   </div>
   <h2 id="صႣ">In suscipit justo in turpis aliquet convallis. ゾ タ ダ チ ヂ ッ ツ ヅ テ デ ト ド ナ ニ ヌ ネ ノ.</h2>
   <a href="#">༫ ༬ ༭ ༮ ༯ ༰ ༱ ༲ ༳ ༴ ༵</a>
@@ -70,9 +70,9 @@ em.ଽ {
     <li><a href="#" title="the № and the Å">ໝ</a><li>
     <li class="test-Ø">µ ¶</li>
   </ul>
-  <div class="☍" id="༼">
+  <div class="ㅒ" id="༼">
    ៀ ៅ ៉
-   <p id="⌘">I will display &larr;</p>
+   <p id="়">I will display &larr;</p>
    <em class="欄 爛 蘭 ଽ">㊝ &#8594; ℉ stuff and things</em>
   </div> 
 </body>


### PR DESCRIPTION
I have removed unicode characters within style declarations that lacked inliner support and resulted in errors. These were typically shapes and symbols, rather than languages.