### PR TITLE
Escape brace in regexp to silence warnings in 5.26

### DIFF
--- a/lib/CSS/Inliner/Parser.pm
+++ b/lib/CSS/Inliner/Parser.pm
@@ -209,7 +209,7 @@ sub read {
           }
         }
 
-        $atrule =~ /^\s*(@[\w-]+)\s*([^{]*){\s*(.*?})$/s;
+        $atrule =~ /^\s*(@[\w-]+)\s*([^{]*)\{\s*(.*?})$/s;
 
         $self->add_at_rule({ type => $1, prelude => $2, block => $3 });
       }


### PR DESCRIPTION
When using CSS::Inliner with perl 5.26 the following warning is generated:-

    Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.30), 
    passed through in regex; marked by <-- HERE in 
    m/^\s*(@[\w-]+)\s*([^{]*){ <-- HERE \s*(.*?})$/ at .../CSS/Inliner/Parser.pm line 212.

This is the minimum fix to silence that