### PR TITLE
adapt tests to rawgit having changed to https (allows module to install again)

### DIFF
--- a/t/embedded_style_block.t
+++ b/t/embedded_style_block.t
@@ -10,14 +10,14 @@ use LWP::Simple;
 use FindBin qw($Bin);
 
 eval {
-  get('http://rawgit.com') or die $@;
+  get('https://rawgit.com') or die $@;
 };
 
 # conditional test plan based on whether or not the endpoint can be reached - frequently can't by cpan testers
 plan $@ ? (skip_all => 'Connectivity for endpoint required for test cannot be established') : (tests => 1);
 
 my $html_path = "$Bin/html/";
-my $test_url = 'http://rawgit.com/kamelkev/CSS-Inliner/master/t/html/embedded_style.html';
+my $test_url = 'https://rawgit.com/kamelkev/CSS-Inliner/master/t/html/embedded_style.html';
 my $result_file = $html_path . 'embedded_style_result.html';
 
 open( my $fh, $result_file ) or die "can't open $result_file: $!!\n";

--- a/t/html/embedded_style_result.html
+++ b/t/html/embedded_style_result.html
@@ -7,7 +7,7 @@
    <tr>
     <td id="header" style="color: #ff0000;">
      <div id="top" style="color: #259e00;">
-      <p style="background: url('http://rawgit.com/images/background.png'); text-decoration: line-through;">Email not displaying correctly? <a href="http://rawgit.com/view.html" style="color: #f5a100; font-size: 30px; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
+      <p style="background: url('https://rawgit.com/images/background.png'); text-decoration: line-through;">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="color: #f5a100; font-size: 30px; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
      </div>
     </td>
    </tr>


### PR DESCRIPTION
Right now all attempts to test fail due to rawgit having changed to https. Thix commit fixes the test and allows installation again on all platforms.