### PR TITLE
fix test fail

### DIFF
--- a/t/embedded_style_block.t
+++ b/t/embedded_style_block.t
@@ -27,4 +27,4 @@ my $inliner = CSS::Inliner->new();
 $inliner->fetch_file({ url => $test_url });
 my $inlined = $inliner->inlinify();
 
-ok($inlined eq $correct_result, 'result was correct');
+is($inlined, $correct_result, 'result was correct');

--- a/t/html/embedded_style_result.html
+++ b/t/html/embedded_style_result.html
@@ -7,7 +7,7 @@
    <tr>
     <td id="header" style="color: #ff0000;">
      <div id="top" style="color: #259e00;">
-      <p style="background: url('http://rawgit.com/images/background.png'); text-decoration: line-through;">Email not displaying correctly? <a href="http://rawgit.com/view.html" style="color: #f5a100; font-size: 30px; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
+      <p style="background: url('https://rawgit.com/images/background.png'); text-decoration: line-through;">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="color: #f5a100; font-size: 30px; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
      </div>
     </td>
    </tr>


### PR DESCRIPTION
I think this test started failing because the website started using https instead of http.  Without this patch I get a test fail:

```
helix% prove -lvm t/embedded_style_block.t 
t/embedded_style_block.t .. 
1..1
not ok 1 - result was correct

#   Failed test 'result was correct'
#   at t/embedded_style_block.t line 30.
# Looks like you failed 1 test of 1.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 

Test Summary Report
-------------------
t/embedded_style_block.t (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.16 cusr  0.02 csys =  0.19 CPU)
Result: FAIL
```