### PR TITLE
Ignore deprecated "type" attribute of style tag and encode inlined styles

### DIFF
--- a/lib/CSS/Inliner.pm
+++ b/lib/CSS/Inliner.pm
@@ -785,7 +785,7 @@ sub __expand_stylesheet {
     #absolutized the assetts within the stylesheet that are relative
     $content =~ s/(url\()["']?((?:(?!https?:\/\/)(?!\))[^"'])*)["']?(?=\))/$self->__fix_relative_url({ prefix => $1, url => $2, base => $baseref })/exsgi;
 
-    my $stylesheet = HTML::Element->new('style', type => 'text/css', rel=> 'stylesheet');
+    my $stylesheet = HTML::Element->new('style');
     $stylesheet->push_content($content);
 
     $i->replace_with($stylesheet);
@@ -801,7 +801,7 @@ sub __expand_stylesheet {
     # absolutize the assets within the stylesheet that are relative
     $content =~ s/(url\()["']?((?:(?!https?:\/\/)(?!\))[^"'])*)["']?(?=\))/$self->__fix_relative_url({ prefix => $1, url => $2, base => $baseref })/exsgi;
 
-    my $stylesheet = HTML::Element->new('style', type => 'text/css', rel=> 'stylesheet');
+    my $stylesheet = HTML::Element->new('style');
     $stylesheet->push_content($content);
 
     $i->replace_with($stylesheet);
@@ -870,7 +870,7 @@ sub _validate_html {
 
     if ($body) {
       # located spurious <style> tags that won't be handled
-      my @spurious_style = $body->look_down('_tag','style','type','text/css');
+      my @spurious_style = $body->look_down('_tag','style');
 
       if (scalar @spurious_style) {
         $self->_report_warning({ info => 'Unexpected reference to stylesheet within document body skipped' });
@@ -892,7 +892,7 @@ sub _parse_stylesheet {
   my $stylesheet_root = $self->_relaxed() ? $self->_html_tree() : $self->_html_tree->look_down('_tag', 'head');
 
   # get the <style> nodes
-  my @style = $stylesheet_root->look_down('_tag','style','type','text/css');
+  my @style = $stylesheet_root->look_down('_tag','style');
 
   foreach my $i (@style) {
     #process this node if the html media type is screen, all or undefined (which defaults to screen)

--- a/lib/CSS/Inliner.pm
+++ b/lib/CSS/Inliner.pm
@@ -12,6 +12,7 @@ use URI;
 
 use CSS::Inliner::Parser;
 use CSS::Inliner::TreeBuilder;
+use HTML::Entities;
 
 =pod
 
@@ -492,7 +493,7 @@ sub inlinify {
 
       # styles already inlined have greater precedence
       if (defined($element->attr('style'))) {
-        my $cur_style = $self->_split({ style => $element->attr('style') });
+        my $cur_style = $self->_split({ style => decode_entities($element->attr('style')) });
         push @new_style, @$cur_style;
         push @new_important_style, _grep_important_declarations($cur_style);
       }
@@ -500,7 +501,7 @@ sub inlinify {
       # override styles with !important styles
       push @new_style, @new_important_style;
 
-      $element->attr('style', $self->_expand({ declarations => \@new_style }));
+      $element->attr('style', encode_entities($self->_expand({ declarations => \@new_style })));
     }
 
     #at this point we have a document that contains the expanded inlined stylesheet
@@ -930,7 +931,7 @@ sub _collapse_inline_styles {
     if ($i->attr('style')) {
 
       #flatten out the styles currently in place on this entity
-      my $existing_styles = $i->attr('style');
+      my $existing_styles = decode_entities($i->attr('style'));
       $existing_styles =~ tr/\n\t/  /;
 
       # hold the property value pairs
@@ -948,7 +949,7 @@ sub _collapse_inline_styles {
       }
 
       $collapsed_style =~ s/\s*$//;
-      $i->attr('style', $collapsed_style);
+      $i->attr('style', encode_entities($collapsed_style));
     }
 
     #if we have specifically asked to remove the inlined attrs, remove them

--- a/t/embedded_style_block.t
+++ b/t/embedded_style_block.t
@@ -23,8 +23,23 @@ eval {
 };
 
 ## conditional test plan based on whether or not the endpoint can be reached - frequently can't by cpan testers
-plan $@ ? (skip_all => 'Connectivity for endpoint required for test cannot be established') : (tests => 1);
+plan $@ ? (skip_all => 'Connectivity for endpoint required for test cannot be established') : (tests => 2);
 
 my $inlined = $inliner->inlinify();
+
+ok($inlined eq $correct_result, 'result was correct');
+
+$result_file = $html_path . 'embedded_style_result_encoded.html';
+
+open( $fh, $result_file ) or die "can't open $result_file: $!!\n";
+$correct_result = do { local( $/ ) ; <$fh> } ;
+
+$inliner = CSS::Inliner->new({encode_entities => 1});
+
+eval {
+  $inliner->fetch_file({ url => $test_url });
+};
+
+$inlined = $inliner->inlinify();
 
 ok($inlined eq $correct_result, 'result was correct');

--- a/t/html/embedded_style_result.html
+++ b/t/html/embedded_style_result.html
@@ -7,7 +7,7 @@
    <tr>
     <td id="header" style="color: #ff0000;">
      <div id="top" style="color: #259e00;">
-      <p style="text-decoration: line-through; background: url('https://rawgit.com/images/background.png');">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="font-size: 30px; color: #f5a100; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
+      <p style="text-decoration: line-through; background: url(&#39;https://rawgit.com/images/background.png&#39;);">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="font-size: 30px; color: #f5a100; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
      </div>
     </td>
    </tr>

--- a/t/html/embedded_style_result.html
+++ b/t/html/embedded_style_result.html
@@ -7,7 +7,7 @@
    <tr>
     <td id="header" style="color: #ff0000;">
      <div id="top" style="color: #259e00;">
-      <p style="text-decoration: line-through; background: url(&#39;https://rawgit.com/images/background.png&#39;);">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="font-size: 30px; color: #f5a100; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
+      <p style="text-decoration: line-through; background: url('https://rawgit.com/images/background.png');">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="font-size: 30px; color: #f5a100; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
      </div>
     </td>
    </tr>

--- a/t/html/embedded_style_result_encoded.html
+++ b/t/html/embedded_style_result_encoded.html
@@ -1,0 +1,16 @@
+<html>
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-type" />
+ </head>
+ <body>
+  <table id="layout" style="color: #0084ff; text-align: left;">
+   <tr>
+    <td id="header" style="color: #ff0000;">
+     <div id="top" style="color: #259e00;">
+      <p style="text-decoration: line-through; background: url(&#39;https://rawgit.com/images/background.png&#39;);">Email not displaying correctly? <a href="https://rawgit.com/view.html" style="font-size: 30px; color: #f5a100; font-weight: bold; text-decoration: underline;" title="View this email in your browser.">View it in your browser</a></p>
+     </div>
+    </td>
+   </tr>
+  </table>
+ </body>
+</html>


### PR DESCRIPTION
I recently encountered an html generated by Outlook with a snippet like the following:

<style>
...
font-family: "Microsoft Sans Serif";
...
</style>

The first commit is to support <style> without "type" attribute, the other is to encode inlined styles so meta characters like quotes can be inlined correctly.

Thanks!

-sunnavy